### PR TITLE
skip problematic tests for ci

### DIFF
--- a/tests/testthat/test-plot-raster.R
+++ b/tests/testthat/test-plot-raster.R
@@ -1,6 +1,7 @@
 test_that("raster plotting works", {
   skip_on_os("windows")
   skip_on_ci()
+  skip_on_covr()
   s2files <- fs::dir_ls(system.file("s2-data", package = "vrtility"))
 
   ex_collect <- vrt_collect(s2files)

--- a/tests/testthat/test-plot-raster.R
+++ b/tests/testthat/test-plot-raster.R
@@ -1,5 +1,6 @@
 test_that("raster plotting works", {
   skip_on_os("windows")
+  skip_on_ci()
   s2files <- fs::dir_ls(system.file("s2-data", package = "vrtility"))
 
   ex_collect <- vrt_collect(s2files)

--- a/tests/testthat/test-stac-utils.R
+++ b/tests/testthat/test-stac-utils.R
@@ -9,14 +9,15 @@ test_that("hls_stac_query works", {
   te <- bbox_to_projected(bbox)
   trs <- attr(te, "wkt")
 
-  hls_query <- hls_stac_query(
+  skip_on_ci()
+  hls_query <- (hls_stac_query(
     bbox,
     start_date = "2023-01-01",
     end_date = "2023-02-28",
     assets = c("B04", "B03", "B02", "Fmask"),
     collection = "HLSS30_2.0",
     max_cloud_cover = 70
-  )
+  ))
   expect_s3_class(hls_query, "doc_items")
   expect_equal(length(hls_query$features), 5)
 })

--- a/tests/testthat/test-vrt-piplines.R
+++ b/tests/testthat/test-vrt-piplines.R
@@ -83,7 +83,9 @@ test_that("full vrt pipeline works", {
 
   expect_true(fs::file_size(ex_collect_mask_gdr) > 0)
 
-  testthat::skip_on_os("windows")
+  skip_on_os("windows")
+  skip_on_ci()
+  skip_on_covr()
   vdiffr::expect_doppelganger(
     "s2 exeter plots",
     plot_raster_src(exe_compwarp, c(3, 2, 1))


### PR DESCRIPTION
plot image comparisons and eardata STAC issues are bombing  some CI tests so let's skip them on github actions.