### PR TITLE
Fixes typos in stac-utils.R and lint code

### DIFF
--- a/R/stac-utils.R
+++ b/R/stac-utils.R
@@ -103,7 +103,7 @@ sign_planetary_computer <- function(
   items,
   subscription_key = Sys.getenv("MPC_TOKEN")
 ) {
-  if (subscription_key == "") {
+  if (!nzchar(subscription_key)) {
     cli::cli_warn(
       c(
         "!" = "No subscription key provided. Using default signing method.",

--- a/R/stac-utils.R
+++ b/R/stac-utils.R
@@ -92,7 +92,7 @@ stac_query <- function(
 #' @param subscription_key Optionally (but strongly recommended), a
 #' subscription key associated with your MPC account. At the time of writing,
 #' this is required for downloading Sentinel 1 RTC products, as well as NAIP
-#' imagery. This key willb be automatically used if the environment
+#' imagery. This key will be automatically used if the environment
 #' variable `MPC_TOKEN` is set.
 #'
 #' @returns A STACItemCollection object with signed assets url.

--- a/R/stac-utils.R
+++ b/R/stac-utils.R
@@ -38,7 +38,7 @@ format_stac_date <- function(x) {
 #'  limit = 10
 #' )
 #'
-#' mpc_singed <- sign_planetary_computer(s2_its)
+#' mpc_signed <- sign_planetary_computer(s2_its)
 #'
 
 stac_query <- function(

--- a/vignettes/cdse-sentinel-2.Rmd
+++ b/vignettes/cdse-sentinel-2.Rmd
@@ -40,7 +40,7 @@ Get the official authentication documentation [here](https://documentation.datas
 You will need a CDSE account to access the data. Get yourself one from 
 [here](https://identity.dataspace.copernicus.eu/auth/realms/CDSE/protocol/openid-connect/auth?client_id=cdse-public&response_type=code&scope=openid&redirect_uri=https%3A//dataspace.copernicus.eu/account/confirmed/1).
 
-Once, you're registred, navigate to the [S3 credentials page](https://eodata-s3keysmanager.dataspace.copernicus.eu/)
+Once, you're registered, navigate to the [S3 credentials page](https://eodata-s3keysmanager.dataspace.copernicus.eu/)
 and create an "access key" and a "secret access key". Then Save these keys in your
 `.Renviron` file as `CDSE_ACCESS_KEY` and `CDSE_SECRET_KEY` respectively.
 


### PR DESCRIPTION
I didn't redoc, just fixed the typos that I noted.

Also lints code using `!nzchar()` to check for an empty string rather than `== ""`.