### PR TITLE
remove numpy version pin - enforce more recent version. numba now supports this.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vrtility
 Title: Efficient Raster Processing Pipelines Using GDAL Virtual Rasters
-Version: 0.3.3
+Version: 0.3.4
 Authors@R: 
     person("Hugh", "Graham", , "hugh.graham@permianglobal.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9451-5010"))

--- a/R/vrtility-package.R
+++ b/R/vrtility-package.R
@@ -132,9 +132,8 @@
 
 .onLoad <- function(libname, pkgname) {
   # Declare Python dependency (does NOT trigger Python initialization).
-  # For numba compatibility e.g. for fastnanquantile;
-  # track this issue: https://github.com/numba/numba/issues/10263
-  reticulate::py_require("numpy<2.4.0")
+  # numba now supports numpy 2.4.0: https://github.com/numba/numba/issues/10263#issuecomment-3946988146
+  reticulate::py_require("numpy>=2.4.0")
   cache_init_checks()
   vrt_opts_set()
 


### PR DESCRIPTION
allow latest numpy version - support is available for numba and fasnanquantile