### PR TITLE
Feat/vrt save bundle

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vrtility
 Title: Efficient Raster Processing Pipelines Using GDAL Virtual Rasters
-Version: 0.3.5
+Version: 0.3.5.9000
 Authors@R: 
     person("Hugh", "Graham", , "hugh.graham@permianglobal.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9451-5010"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vrtility
 Title: Efficient Raster Processing Pipelines Using GDAL Virtual Rasters
-Version: 0.3.5.9000
+Version: 0.4.0
 Authors@R: 
     person("Hugh", "Graham", , "hugh.graham@permianglobal.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9451-5010"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # vrtility 0.4.0
 
+## New features
+
+* `vrt_save()` gained `bundle = TRUE` to write a saved VRT alongside copies
+  of every intermediate VRT it depends on, with paths rewritten relative to
+  the output directory. The result survives wiping the VRT cache. Adding
+  `include_rasters = TRUE` also copies local raster leaves into the bundle
+  for full portability; remote sources (URLs, `/vsicurl/`, ...) are detected
+  and reported in a single warning (#110).
+
 # vrtility 0.3.3
 
 ## Improvements

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# vrtility (development version)
+
 # vrtility 0.3.3
 
 ## Improvements

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# vrtility (development version)
+# vrtility 0.4.0
 
 # vrtility 0.3.3
 

--- a/R/vrt-bundle.R
+++ b/R/vrt-bundle.R
@@ -1,0 +1,144 @@
+#' Bundle a saved VRT and all its dependencies into a self-contained directory
+#'
+#' Walks the VRT dependency tree, copies every intermediate VRT (and optionally
+#' the underlying local rasters) into the directory containing `outfile`, and
+#' rewrites all `<SourceFilename>` paths to be relative to that directory.
+#' Remote sources (URLs, /vsicurl/, /vsis3/, ...) are detected via
+#' [assert_is_url()] and left in place: they cannot be bundled.
+#'
+#' @param vrt_xml An `xml_document` of the root VRT (already in memory).
+#' @param outfile The destination path for the root VRT. Its parent directory
+#'   becomes the bundle root.
+#' @param cache_dir The cache directory used to resolve relative paths in the
+#'   root VRT (typically `getOption("vrt.cache")`).
+#' @param include_rasters If `TRUE`, copy local raster sources (e.g. GeoTIFFs)
+#'   into the bundle as well. Remote sources are skipped with a single warning.
+#' @return The absolute path to the bundled root VRT (invisibly).
+#' @noRd
+#' @keywords internal
+write_vrt_bundle <- function(
+  vrt_xml,
+  outfile,
+  cache_dir,
+  include_rasters = FALSE
+) {
+  outfile <- fs::path_abs(outfile)
+  bundle_dir <- fs::path_dir(outfile)
+  fs::dir_create(bundle_dir)
+
+  # registry: map original absolute source path -> bundled basename
+  registry <- new.env(parent = emptyenv())
+  # processed: bundled VRTs already walked (prevents re-rewriting + spurious
+  # warnings when the same intermediate VRT is referenced via multiple bands)
+  processed <- new.env(parent = emptyenv())
+  # remote_sources: URLs encountered while include_rasters = TRUE; surfaced as
+  # a single end-of-walk warning
+  remote_sources <- new.env(parent = emptyenv())
+
+  # seed the registry with the user-chosen outfile name so we don't clobber it
+  assign(outfile, fs::path_file(outfile), envir = registry)
+
+  bundled_name <- function(src_abs) {
+    if (exists(src_abs, envir = registry, inherits = FALSE)) {
+      return(get(src_abs, envir = registry))
+    }
+    base <- fs::path_file(src_abs)
+    candidate <- base
+    used <- purrr::map_chr(ls(registry), ~ get(.x, envir = registry))
+    i <- 1L
+    while (
+      candidate %in% used ||
+        fs::file_exists(fs::path(bundle_dir, candidate))
+    ) {
+      candidate <- paste0(
+        fs::path_ext_remove(base),
+        "_",
+        i,
+        ".",
+        fs::path_ext(base)
+      )
+      i <- i + 1L
+    }
+    assign(src_abs, candidate, envir = registry)
+    candidate
+  }
+
+  process <- function(vrt_in_bundle, original_dir) {
+    if (exists(vrt_in_bundle, envir = processed, inherits = FALSE)) {
+      return(invisible())
+    }
+    assign(vrt_in_bundle, TRUE, envir = processed)
+
+    doc <- xml2::read_xml(vrt_in_bundle)
+    src_nodes <- xml2::xml_find_all(doc, ".//SourceFilename")
+
+    purrr::walk(src_nodes, function(node) {
+      raw <- xml2::xml_text(node)
+
+      # Remote sources cannot be bundled; leave them in place.
+      if (assert_is_url(raw)) {
+        if (include_rasters) {
+          assign(raw, TRUE, envir = remote_sources)
+        }
+        return(invisible())
+      }
+
+      rel_attr <- xml2::xml_attr(node, "relativeToVRT")
+      is_relative <- !is.na(rel_attr) && rel_attr == "1"
+
+      src_abs <- if (is_relative) {
+        fs::path_abs(fs::path(original_dir, raw))
+      } else {
+        fs::path_abs(raw)
+      }
+
+      if (!fs::file_exists(src_abs)) {
+        cli::cli_warn(
+          "Skipping missing source {.path {src_abs}}."
+        )
+        return(invisible())
+      }
+
+      is_vrt <- tolower(fs::path_ext(src_abs)) == "vrt"
+
+      if (is_vrt || include_rasters) {
+        new_name <- bundled_name(src_abs)
+        new_path <- fs::path(bundle_dir, new_name)
+        if (!fs::file_exists(new_path)) {
+          fs::file_copy(src_abs, new_path)
+        }
+        xml2::xml_set_text(node, new_name)
+        xml2::xml_set_attr(node, "relativeToVRT", "1")
+
+        if (is_vrt) {
+          # recurse using the *original* dir of this nested VRT so its
+          # own relative paths resolve against the cache, not the bundle.
+          process(new_path, fs::path_dir(src_abs))
+        }
+      } else {
+        # local raster, include_rasters = FALSE: keep an absolute reference
+        xml2::xml_set_text(node, src_abs)
+        xml2::xml_set_attr(node, "relativeToVRT", "0")
+      }
+    })
+
+    xml2::write_xml(doc, vrt_in_bundle)
+  }
+
+  # write the root VRT to its destination, then walk it
+  xml2::write_xml(vrt_xml, outfile)
+  process(outfile, cache_dir)
+
+  if (include_rasters && length(ls(remote_sources)) > 0) {
+    remotes <- ls(remote_sources)
+    cli::cli_warn(c(
+      "!" = paste0(
+        "{length(remotes)} remote source{?s} cannot be bundled and ",
+        "{?was/were} left as URL{?s}:"
+      ),
+      purrr::set_names(remotes, rep("*", length(remotes)))
+    ))
+  }
+
+  invisible(normalizePath(outfile))
+}

--- a/R/vrt-save.R
+++ b/R/vrt-save.R
@@ -1,8 +1,17 @@
 #' Save a vrt_block object to disk
 #' @param x A `vrt_stack` of `vrt_block` object.
 #' @param outfile A character string of the output file
+#' @param bundle Logical. If `TRUE`, copy every intermediate VRT in the
+#'   dependency tree into the directory containing `outfile` and rewrite all
+#'   `<SourceFilename>` paths relative to that directory. The result is a
+#'   self-contained bundle that survives wiping the VRT cache. Remote sources
+#'   (URLs, `/vsicurl/`, ...) cannot be bundled and are left untouched.
+#' @param include_rasters Logical. Only meaningful when `bundle = TRUE`. If
+#'   `TRUE`, copy local raster leaves (e.g. GeoTIFFs) into the bundle as well,
+#'   producing a fully portable directory. Remote raster sources are skipped
+#'   and surfaced as a single warning.
 #' @export
-vrt_save <- function(x, outfile) {
+vrt_save <- function(x, outfile, bundle = FALSE, include_rasters = FALSE) {
   UseMethod("vrt_save")
 }
 
@@ -19,13 +28,32 @@ vrt_save.default <- function(x, ...) {
 #' @export
 vrt_save.vrt_block <- function(
   x,
-  outfile = fs::file_temp(tmp_dir = getOption("vrt.cache"), ext = "vrt")
+  outfile = fs::file_temp(tmp_dir = getOption("vrt.cache"), ext = "vrt"),
+  bundle = FALSE,
+  include_rasters = FALSE
 ) {
   if (fs::path_ext(outfile) != "vrt") {
     cli::cli_abort("The `outfile` extension must be'.vrt'.")
   }
+  if (include_rasters && !bundle) {
+    cli::cli_abort(
+      c(
+        "!" = "{.arg include_rasters} requires {.code bundle = TRUE}.",
+        "i" = "Set {.code bundle = TRUE} to copy raster sources into a self-contained directory."
+      )
+    )
+  }
 
   vrt_xml <- xml2::read_xml(x$vrt)
+
+  if (bundle) {
+    return(invisible(write_vrt_bundle(
+      vrt_xml,
+      outfile,
+      cache_dir = getOption("vrt.cache"),
+      include_rasters = include_rasters
+    )))
+  }
 
   if (fs::path_has_parent(outfile, getOption("vrt.cache"))) {
     xml2::write_xml(vrt_xml, outfile)

--- a/man/vrt_save.Rd
+++ b/man/vrt_save.Rd
@@ -4,12 +4,23 @@
 \alias{vrt_save}
 \title{Save a vrt_block object to disk}
 \usage{
-vrt_save(x, outfile)
+vrt_save(x, outfile, bundle = FALSE, include_rasters = FALSE)
 }
 \arguments{
 \item{x}{A \code{vrt_stack} of \code{vrt_block} object.}
 
 \item{outfile}{A character string of the output file}
+
+\item{bundle}{Logical. If \code{TRUE}, copy every intermediate VRT in the
+dependency tree into the directory containing \code{outfile} and rewrite all
+\verb{<SourceFilename>} paths relative to that directory. The result is a
+self-contained bundle that survives wiping the VRT cache. Remote sources
+(URLs, \verb{/vsicurl/}, ...) cannot be bundled and are left untouched.}
+
+\item{include_rasters}{Logical. Only meaningful when \code{bundle = TRUE}. If
+\code{TRUE}, copy local raster leaves (e.g. GeoTIFFs) into the bundle as well,
+producing a fully portable directory. Remote raster sources are skipped
+and surfaced as a single warning.}
 }
 \description{
 Save a vrt_block object to disk

--- a/tests/testthat/test-save-vrt.R
+++ b/tests/testthat/test-save-vrt.R
@@ -76,10 +76,7 @@ test_that("vrt_save bundle mode produces a self-contained directory", {
   saved <- vrt_save(ex_vrt, bundle_root, bundle = TRUE)
 
   expect_true(fs::file_exists(saved))
-  expect_identical(
-    as.character(fs::path_dir(saved)),
-    as.character(fs::path_abs(fs::path_dir(bundle_root)))
-  )
+  expect_identical(fs::path_file(saved), fs::path_file(bundle_root))
 
   bundle_files <- fs::dir_ls(fs::path_dir(saved))
   expect_gt(length(bundle_files), 1) # root VRT plus intermediates

--- a/tests/testthat/test-save-vrt.R
+++ b/tests/testthat/test-save-vrt.R
@@ -50,3 +50,142 @@ test_that("save_vrt works", {
   })
   expect_type(r2, "integer")
 })
+
+
+test_that("vrt_save bundle mode produces a self-contained directory", {
+  s2files <- fs::dir_ls(
+    system.file("s2-data", package = "vrtility"),
+    regexp = "exe_2024-0[78].*\\.tif$"
+  )
+
+  ex_vrt <- s2files |>
+    vrt_collect() |>
+    vrt_stack()
+
+  ref_file <- vrt_save(ex_vrt)
+  ref_vals <- terra::values(terra::rast(ref_file))
+
+  bundle_root <- fs::path(withr::local_tempdir(), "diff.vrt")
+  saved <- vrt_save(ex_vrt, bundle_root, bundle = TRUE)
+
+  expect_true(fs::file_exists(saved))
+  expect_identical(
+    as.character(fs::path_dir(saved)),
+    as.character(fs::path_abs(fs::path_dir(bundle_root)))
+  )
+
+  bundle_files <- fs::dir_ls(fs::path_dir(saved))
+  expect_gt(length(bundle_files), 1) # root VRT plus intermediates
+
+  # every <SourceFilename> in the bundled VRTs that is not a URL must resolve
+  # to a file inside the bundle (relativeToVRT = "1") or to an absolute path
+  # that exists on disk (a non-bundled local raster).
+  vrt_paths <- bundle_files[fs::path_ext(bundle_files) == "vrt"]
+  purrr::walk(vrt_paths, function(p) {
+    doc <- xml2::read_xml(p)
+    purrr::walk(
+      xml2::xml_find_all(doc, ".//SourceFilename"),
+      function(node) {
+        raw <- xml2::xml_text(node)
+        if (assert_is_url(raw)) return(invisible())
+        rel <- xml2::xml_attr(node, "relativeToVRT")
+        if (!is.na(rel) && rel == "1") {
+          expect_true(fs::file_exists(fs::path(fs::path_dir(p), raw)))
+        } else {
+          expect_true(fs::file_exists(raw))
+        }
+      }
+    )
+  })
+
+  # bundle output must produce identical pixel values
+  expect_equal(terra::values(terra::rast(saved)), ref_vals)
+})
+
+
+test_that("vrt_save include_rasters bundles local sources and is portable", {
+  s2files <- fs::dir_ls(
+    system.file("s2-data", package = "vrtility"),
+    regexp = "exe_2024-0[78].*\\.tif$"
+  )
+
+  ex_vrt <- s2files |>
+    vrt_collect() |>
+    vrt_stack()
+
+  ref_vals <- terra::values(terra::rast(vrt_save(ex_vrt)))
+
+  bundle_dir <- withr::local_tempdir()
+  bundle_root <- fs::path(bundle_dir, "diff.vrt")
+  saved <- vrt_save(
+    ex_vrt,
+    bundle_root,
+    bundle = TRUE,
+    include_rasters = TRUE
+  )
+
+  # all source rasters should now live inside the bundle dir
+  src_basenames <- fs::path_file(s2files)
+  expect_true(all(
+    fs::file_exists(fs::path(fs::path_dir(saved), src_basenames))
+  ))
+
+  # portability: wipe the cache, the bundle should still resolve
+  cache_vrts <- fs::dir_ls(getOption("vrt.cache"), glob = "*.vrt")
+  fs::file_delete(cache_vrts)
+  expect_equal(terra::values(terra::rast(saved)), ref_vals)
+})
+
+
+test_that("vrt_save validates include_rasters / bundle combination", {
+  s2files <- fs::dir_ls(
+    system.file("s2-data", package = "vrtility"),
+    regexp = "exe_2024-0[78].*\\.tif$"
+  )
+  ex_vrt <- s2files |>
+    vrt_collect() |>
+    vrt_stack()
+
+  expect_error(
+    vrt_save(
+      ex_vrt,
+      fs::path(withr::local_tempdir(), "x.vrt"),
+      include_rasters = TRUE
+    ),
+    "include_rasters"
+  )
+})
+
+
+test_that("vrt_save bundle warns once for remote sources with include_rasters", {
+  fake_xml <- xml2::read_xml(
+    paste0(
+      "<VRTDataset rasterXSize=\"10\" rasterYSize=\"10\">",
+      "<VRTRasterBand dataType=\"Byte\" band=\"1\">",
+      "<SimpleSource>",
+      "<SourceFilename relativeToVRT=\"0\">",
+      "/vsicurl/https://example.com/foo.tif",
+      "</SourceFilename>",
+      "<SourceBand>1</SourceBand>",
+      "</SimpleSource>",
+      "</VRTRasterBand>",
+      "</VRTDataset>"
+    )
+  )
+  fake_block <- structure(
+    list(vrt = as.character(fake_xml)),
+    class = c("vrt_block", "list")
+  )
+
+  out <- fs::path(withr::local_tempdir(), "remote.vrt")
+  expect_warning(
+    vrt_save(fake_block, out, bundle = TRUE, include_rasters = TRUE),
+    "remote source"
+  )
+
+  # no warning when the user has not opted into raster bundling
+  out2 <- fs::path(withr::local_tempdir(), "remote2.vrt")
+  expect_no_warning(
+    vrt_save(fake_block, out2, bundle = TRUE, include_rasters = FALSE)
+  )
+})

--- a/tests/testthat/test-save-vrt.R
+++ b/tests/testthat/test-save-vrt.R
@@ -52,6 +52,13 @@ test_that("save_vrt works", {
 })
 
 
+read_vrt_values <- function(path) {
+  ds <- methods::new(gdalraster::GDALRaster, path)
+  on.exit(if (ds$isOpen()) ds$close())
+  gdalraster::read_ds(ds)
+}
+
+
 test_that("vrt_save bundle mode produces a self-contained directory", {
   s2files <- fs::dir_ls(
     system.file("s2-data", package = "vrtility"),
@@ -63,7 +70,7 @@ test_that("vrt_save bundle mode produces a self-contained directory", {
     vrt_stack()
 
   ref_file <- vrt_save(ex_vrt)
-  ref_vals <- terra::values(terra::rast(ref_file))
+  ref_vals <- read_vrt_values(ref_file)
 
   bundle_root <- fs::path(withr::local_tempdir(), "diff.vrt")
   saved <- vrt_save(ex_vrt, bundle_root, bundle = TRUE)
@@ -99,7 +106,7 @@ test_that("vrt_save bundle mode produces a self-contained directory", {
   })
 
   # bundle output must produce identical pixel values
-  expect_equal(terra::values(terra::rast(saved)), ref_vals)
+  expect_equal(read_vrt_values(saved), ref_vals)
 })
 
 
@@ -113,7 +120,7 @@ test_that("vrt_save include_rasters bundles local sources and is portable", {
     vrt_collect() |>
     vrt_stack()
 
-  ref_vals <- terra::values(terra::rast(vrt_save(ex_vrt)))
+  ref_vals <- read_vrt_values(vrt_save(ex_vrt))
 
   bundle_dir <- withr::local_tempdir()
   bundle_root <- fs::path(bundle_dir, "diff.vrt")
@@ -133,7 +140,7 @@ test_that("vrt_save include_rasters bundles local sources and is portable", {
   # portability: wipe the cache, the bundle should still resolve
   cache_vrts <- fs::dir_ls(getOption("vrt.cache"), glob = "*.vrt")
   fs::file_delete(cache_vrts)
-  expect_equal(terra::values(terra::rast(saved)), ref_vals)
+  expect_equal(read_vrt_values(saved), ref_vals)
 })
 
 


### PR DESCRIPTION
To support the situation reported in https://github.com/Permian-Global-Research/vrtility/issues/110

vrt_save now comes with two new arguments `bundle` and `include_rasters` which allow users to create self contained vrt pipelines. 